### PR TITLE
chore(core): bump django 5.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.12", "3.13", "3.14"]
+        django: ["5.1", "5.2", "6.0"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Install uv
@@ -27,4 +28,4 @@ jobs:
       - name: Install deps
         run: uv sync --dev
       - name: Run tests
-        run: uv run pytest test
+        run: uv run --with "django~=${{ matrix.django }}" pytest test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,18 @@ authors = [{name = "Curtis Maloney", email = "curtis@tinbrain.net"}]
 license = {text = "MIT"}
 requires-python = ">=3.12"
 dependencies = [
-    "django==6.0.2",
+    "django >=5.1, <6.1",
     "croniter >=6, <6.1",
 ]
 classifiers = [
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Framework :: Django",
-  "Framework :: Django :: 3.1",
+  "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "croniter", specifier = ">=6,<6.1" },
-    { name = "django", specifier = "==6.0.2" },
+    { name = "django", specifier = ">=5.1,<6.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Logic:
Simple dependency cleanup and django bump
 - Cleaned up classifiers
 - Made django dependencies a range
 - update test.yaml to have relevant python versions.
 - Tested each django version with `uv run --with Django==version pytest test`

Python: 3.12-3.14
Django: 5.1-6.0